### PR TITLE
해시태그 기준으로 조회 api 개발

### DIFF
--- a/src/main/java/com/project/underline/post/entity/Pick.java
+++ b/src/main/java/com/project/underline/post/entity/Pick.java
@@ -1,5 +1,6 @@
 package com.project.underline.post.entity;
 
+import com.project.underline.common.util.BaseTimeEntity;
 import com.project.underline.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @Table(name = "PICK")
-public class Pick {
+public class Pick extends BaseTimeEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/com/project/underline/post/entity/repository/HashtagQueryRepository.java
+++ b/src/main/java/com/project/underline/post/entity/repository/HashtagQueryRepository.java
@@ -1,0 +1,57 @@
+package com.project.underline.post.entity.repository;
+
+import com.project.underline.post.web.dto.QHashtagSearchResponse_OtherContent_OtherHashtag;
+import com.project.underline.post.web.dto.QHashtagSearchResponse_TargetContent_TargetHashtag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.project.underline.post.entity.QHashtag.hashtag;
+import static com.project.underline.post.entity.QPost.post;
+import static com.project.underline.post.web.dto.HashtagSearchResponse.OtherContent.OtherHashtag;
+import static com.project.underline.post.web.dto.HashtagSearchResponse.TargetContent.TargetHashtag;
+import static com.project.underline.user.entity.QUser.user;
+
+@Repository
+public class HashtagQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public HashtagQueryRepository(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public List<OtherHashtag> getOtherHashtagList(String keyword){
+        return queryFactory
+                .select(new QHashtagSearchResponse_OtherContent_OtherHashtag(
+                                post.postId,
+                                post.content,
+                                post.title,
+                                user.nickname
+                        )
+                )
+                .from(hashtag)
+                .join(hashtag.post, post)
+                .join(post.user, user)
+                .where(hashtag.hashtagName.eq(keyword))
+                .fetch();
+    }
+
+    public List<TargetHashtag> getHashtagListFromTarget(String keyword, Long userId){
+//        select * from post left join hashtag on hashtag.POST_ID = post.POST_ID where hashtag.hashtag_name = 'hashtag1';
+        return queryFactory
+                .select(new QHashtagSearchResponse_TargetContent_TargetHashtag(
+                        post.postId,
+                        post.content,
+                        post.title
+                )
+        )
+        .from(hashtag)
+        .join(hashtag.post, post) // Q. post 테이블 기준으로 짜면 에러메세지 나던데 왜그런거죠? -> hashtag.post is not a root path; nested exception is java.lang.illegalargumentexception: hashtag.post is not a root path
+        .where(hashtag.hashtagName.eq(keyword), post.user.id.eq(userId))
+        .fetch();
+    }
+
+}

--- a/src/main/java/com/project/underline/post/service/HashtagService.java
+++ b/src/main/java/com/project/underline/post/service/HashtagService.java
@@ -1,0 +1,32 @@
+package com.project.underline.post.service;
+
+import com.project.underline.post.entity.repository.HashtagQueryRepository;
+import com.project.underline.post.entity.repository.HashtagRepository;
+import com.project.underline.post.web.dto.HashtagSearchResponse;
+import com.project.underline.user.entity.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class HashtagService {
+    private final HashtagRepository hashtagRepository;
+    private final UserRepository userRepository;
+    private final HashtagQueryRepository hashtagQueryRepository;
+
+    public HashtagSearchResponse searchBasedOnHashtag(String keyword, String userNickname) {
+
+        Long targetUserId = userRepository.findByNickname(userNickname).getId();
+        HashtagSearchResponse hashtagSearchResponse = new HashtagSearchResponse();
+
+        // 요청왔던 데이터 그대로 return
+        hashtagSearchResponse.setBasicInfo(keyword,userNickname);
+
+        // Post테이블을 기준으로 hashtag와 user테이블을 join해야함 -> targetContent
+        hashtagSearchResponse.setTargetContent(hashtagQueryRepository.getHashtagListFromTarget(keyword,targetUserId));
+        hashtagSearchResponse.setOtherContent(hashtagQueryRepository.getOtherHashtagList(keyword));
+
+
+        return hashtagSearchResponse;
+    }
+}

--- a/src/main/java/com/project/underline/post/web/controller/HashtagController.java
+++ b/src/main/java/com/project/underline/post/web/controller/HashtagController.java
@@ -1,0 +1,34 @@
+package com.project.underline.post.web.controller;
+
+import com.project.underline.common.payload.DefaultResponse;
+import com.project.underline.post.service.HashtagService;
+import com.project.underline.post.web.dto.HashtagSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.project.underline.common.metadata.ResponseMessage.SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+public class HashtagController {
+    private final HashtagService hashtagService;
+
+    @GetMapping("/hashtag-search")
+    public ResponseEntity searchBasedOnHashtag(@RequestParam("keyword") String keyword, @RequestParam("user-nickname") String userNickname){
+
+        HashtagSearchResponse hashtagSearchResponse = hashtagService.searchBasedOnHashtag(keyword,userNickname);
+
+        return new ResponseEntity(
+                DefaultResponse.builder()
+                        .statusCode(OK.value())
+                        .message(SUCCESS)
+                        .data(hashtagSearchResponse)
+                        .build()
+                , HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/project/underline/post/web/dto/HashtagSearchResponse.java
+++ b/src/main/java/com/project/underline/post/web/dto/HashtagSearchResponse.java
@@ -1,0 +1,122 @@
+package com.project.underline.post.web.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class HashtagSearchResponse {
+    private String userNickname;
+    private String tagName;
+    private TargetContent targetContent;
+    private OtherContent otherContent;
+
+    public HashtagSearchResponse setBasicInfo(String keyword, String userNickname){
+        this.tagName = keyword;
+        this.userNickname = userNickname;
+        return this;
+    }
+
+    public HashtagSearchResponse setTargetContent(List<TargetContent.TargetHashtag> targetHashtagList){
+        this.targetContent = new TargetContent(targetHashtagList);
+        return this;
+    }
+
+    public HashtagSearchResponse setOtherContent(List<OtherContent.OtherHashtag> otherHashtagList){
+        this.otherContent = new OtherContent(otherHashtagList);
+        return this;
+    }
+
+    public HashtagSearchResponse(){
+    }
+
+    /* 데이터 요청사항 -> 각 데이터가 null 이어도 그대로 내려줘야함 JsonInclude.Include.NON_NULL 사용X */
+    @Getter
+    public static class TargetContent{
+        // 원래 검색하려했던 유저의 해시태그에 의한 게시글 데이터
+        private int totalCount;
+        private List<TargetHashtag> hashtagList;
+
+        @QueryProjection
+        public TargetContent(List<TargetHashtag> targetHashtagLists){
+            this.totalCount = 0;
+            this.hashtagList = new ArrayList<TargetHashtag>();
+
+            for (TargetHashtag targetHashtag: targetHashtagLists) {
+                if(totalCount < 3){
+                    hashtagList.add(targetHashtag);
+                }
+                totalCount+= 1;
+            }
+        }
+
+        @Getter
+        public static class TargetHashtag{
+            private Long postId;
+            private String content;
+            private String source;
+            private int pickCount;
+            private int commentCount;
+            private int textCount;
+            private String title;
+
+            @QueryProjection
+            public TargetHashtag(Long postId,String content,String source,String title){
+                this.postId = postId;
+                this.content = content;
+                this.source = source;
+                this.title = title;
+            }
+
+            @QueryProjection
+            public TargetHashtag(Long postId,String content,String title){ // TO-DO. source 생성되면 해당 생성자 삭제
+                this.postId = postId;
+                this.content = content;
+                this.title = title;
+            }
+        }
+    }
+
+    @Getter
+    public static class OtherContent{
+        // 그 외 다른사람들이 사용한 해시태그
+        private int totalCount;
+        private List<OtherHashtag> hashtagList;
+
+        @QueryProjection
+        public OtherContent(List<OtherHashtag> otherHashtagList){
+            this.totalCount = 0;
+            this.hashtagList = new ArrayList<OtherHashtag>();
+
+            for (OtherHashtag otherHashtag: otherHashtagList) {
+                if(totalCount < 3){
+                    hashtagList.add(otherHashtag);
+                }
+                totalCount+= 1;
+            }
+        }
+
+        @Getter
+        public static class OtherHashtag{
+            private Long postId;
+            private String content;
+            private String source;
+            private int pickCount;
+            private int commentCount;
+            private int textCount;
+            private String title;
+            private String userNickname;
+            private String userProfileImage;
+
+            @QueryProjection
+            public OtherHashtag(Long postId,String content,String title,String userNickname){  // TO-DO. source 생성되면 해당 생성자 삭제
+                this.postId = postId;
+                this.content = content;
+                this.title = title;
+                this.userNickname = userNickname;
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. 이전 기획 상 데이터 항목 중 null인 항목들은 그대로 null로 내려주도록 처리
2. queryDsl 적용
3. 아직 개발하지 않은 테이블과 연관된 목록들은 null값으로 뒀으니 추후 수정필요(ex. source, userImage 등)
4. HashtagSearchResponse의 경우 요구 사항 중 포함 관계 형태가 많아 inner Class를 사용